### PR TITLE
Automatically include string.h when HAVE_MEMSET_S

### DIFF
--- a/configure
+++ b/configure
@@ -356,6 +356,9 @@ __HEREDOC__
 [ ${HAVE_ERR} -eq 0 ] \
 	&& echo "#include <stdarg.h>"
 
+[ ${HAVE_MEMSET_S} -eq 0 ] \
+	&& echo "#include <string.h>"
+
 # Now we handle our HAVE_xxxx values.
 # Most will just be defined as 0 or 1.
 

--- a/configure.in
+++ b/configure.in
@@ -356,6 +356,9 @@ __HEREDOC__
 [ ${HAVE_ERR} -eq 0 ] \
 	&& echo "#include <stdarg.h>"
 
+[ ${HAVE_MEMSET_S} -eq 0 ] \
+	&& echo "#include <string.h>"
+
 # Now we handle our HAVE_xxxx values.
 # Most will just be defined as 0 or 1.
 


### PR DESCRIPTION
The file test-memset_s.c includes string.h but configure did not generate it in config.h.