### PR TITLE
Adding a headerguard to config.h

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -337,6 +337,8 @@ exec > config.h
 # Start with prologue.
 
 cat << __HEREDOC__
+#ifndef __config_h
+#define __config_h
 #ifdef __cplusplus
 #error "Do not use C++: this is a C application."
 #endif
@@ -532,6 +534,10 @@ if [ ${HAVE_SYS_TREE} -eq 0 ]; then
 @CONFIGURE_SYS_TREE_H@
 __HEREDOC__
 fi
+
+cat << __HEREDOC__
+#endif /* __config_h */
+__HEREDOC__
 
 echo "config.h: written" 1>&2
 echo "config.h: written" 1>&3


### PR DESCRIPTION
When including config.h in header files that are included in multiple places on systems that do not provide MD5, many errors wind up being thrown due to redefinition of the MD5 bits.

I'm not sure if this is the correct approach, or if the header guard was omitted intentionally, but adding this allows my code to build on Mac OS and Linux, where it was previously only able to build on OpenBSD.

Here is a small example program that will demonstrate the issue when built on systems that don't provide MD5:  https://gitlab.com/protoCall7/sysqueuetest

If this is not the correct way to solve the issue, any feedback would be greatly appreciated.