### PR TITLE
fts: add <stddef.h> include for NULL

### DIFF
--- a/test-fts.c
+++ b/test-fts.c
@@ -1,3 +1,4 @@
+#include <stddef.h> /* NULL */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fts.h>

--- a/tests.c
+++ b/tests.c
@@ -121,6 +121,7 @@ main(void)
 }
 #endif /* TEST_EXPLICIT_BZERO */
 #if TEST_FTS
+#include <stddef.h> /* NULL */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fts.h>


### PR DESCRIPTION
FTS is currently erroneously not detected, as the test fails with
"error: ‘NULL’ undeclared". It seems that the test uses NULL in a few
places, but <stddef.h> is not included. Add the missing #include.