### PR TITLE
Pass LDFLAGS to cc when running tests

### DIFF
--- a/configure
+++ b/configure
@@ -251,9 +251,9 @@ singletest() {
 	extralib=""
 	cat 1>&3 << __HEREDOC__
 ${1}: testing...
-${COMP} -DTEST_${2} ${3} -o test-${1} tests.c ${4}
+${COMP} -DTEST_${2} ${3} -o test-${1} tests.c ${LDFLAGS} ${4}
 __HEREDOC__
-	if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${4} 1>&3 2>&3; then
+	if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${LDFLAGS} ${4} 1>&3 2>&3; then
 		echo "${1}: ${CC} succeeded" 1>&3
 	else 
 		if [ -n "${5}" ] ; then
@@ -262,7 +262,7 @@ __HEREDOC__
 ${1}: testing...
 ${COMP} -DTEST_${2} ${3} -o test-${1} tests.c ${5}
 __HEREDOC__
-			if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${5} 1>&3 2>&3; then
+			if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${LDFLAGS} ${5} 1>&3 2>&3; then
 				echo "${1}: ${CC} succeeded" 1>&3
 				extralib="(with ${5})"
 			else 

--- a/configure.in
+++ b/configure.in
@@ -251,9 +251,9 @@ singletest() {
 	extralib=""
 	cat 1>&3 << __HEREDOC__
 ${1}: testing...
-${COMP} -DTEST_${2} ${3} -o test-${1} tests.c ${4}
+${COMP} -DTEST_${2} ${3} -o test-${1} tests.c ${LDFLAGS} ${4}
 __HEREDOC__
-	if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${4} 1>&3 2>&3; then
+	if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${LDFLAGS} ${4} 1>&3 2>&3; then
 		echo "${1}: ${CC} succeeded" 1>&3
 	else 
 		if [ -n "${5}" ] ; then
@@ -262,7 +262,7 @@ __HEREDOC__
 ${1}: testing...
 ${COMP} -DTEST_${2} ${3} -o test-${1} tests.c ${5}
 __HEREDOC__
-			if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${5} 1>&3 2>&3; then
+			if ${COMP} -DTEST_${2} ${3} -o "test-${1}" tests.c ${LDFLAGS} ${5} 1>&3 2>&3; then
 				echo "${1}: ${CC} succeeded" 1>&3
 				extralib="(with ${5})"
 			else 


### PR DESCRIPTION
When running tests to check for features, pass LDFLAGS, in case the user
gave them to us.

The motivation for this was to be able to pass libbsd-overlay's LDFLAGS,
and thus have oconfigure detect the libbsd copies of a lot of those
functions.