### PR TITLE
Use command -v instead of which(1).

### DIFF
--- a/configure
+++ b/configure
@@ -109,15 +109,15 @@ INSTALL_DATA=
 # It does have gcc, so try that instead.
 # Prefer clang, though.
 
-which ${CC} 2>/dev/null 1>&2 || {
+command -v ${CC} >/dev/null || {
 	echo "${CC} not found: trying clang" 1>&2
 	echo "${CC} not found: trying clang" 1>&3
 	CC=clang
-	which ${CC} 2>/dev/null 1>&2 || {
+	command -v ${CC} >/dev/null || {
 		echo "${CC} not found: trying gcc" 1>&2
 		echo "${CC} not found: trying gcc" 1>&3
 		CC=gcc
-		which ${CC} 2>/dev/null 1>&2 || {
+		command -v ${CC} >/dev/null || {
 			echo "gcc not found: giving up" 1>&2
 			echo "gcc not found: giving up" 1>&3
 			exit 1

--- a/configure.in
+++ b/configure.in
@@ -109,15 +109,15 @@ INSTALL_DATA=
 # It does have gcc, so try that instead.
 # Prefer clang, though.
 
-which ${CC} 2>/dev/null 1>&2 || {
+command -v ${CC} >/dev/null || {
 	echo "${CC} not found: trying clang" 1>&2
 	echo "${CC} not found: trying clang" 1>&3
 	CC=clang
-	which ${CC} 2>/dev/null 1>&2 || {
+	command -v ${CC} >/dev/null || {
 		echo "${CC} not found: trying gcc" 1>&2
 		echo "${CC} not found: trying gcc" 1>&3
 		CC=gcc
-		which ${CC} 2>/dev/null 1>&2 || {
+		command -v ${CC} >/dev/null || {
 			echo "gcc not found: giving up" 1>&2
 			echo "gcc not found: giving up" 1>&3
 			exit 1


### PR DESCRIPTION
As a shell built-in, command -v is better behaved than which(1) (doesn't
print anything to stderr in any situation) and is always available,
while which(1) might not be available in minimal build environments.