### PR TITLE
Provide a way to choose a different AR

### DIFF
--- a/configure
+++ b/configure
@@ -75,9 +75,10 @@ fi
 
 #----------------------------------------------------------------------
 # Initialize all variables here such that nothing can leak in from the
-# environment except for CC and CFLAGS, which we might have passed in.
+# environment except for AR, CC and CFLAGS, which we might have passed in.
 #----------------------------------------------------------------------
 
+AR=`printf "all:\\n\\t@echo \\\$(AR)\\n" | make ${MAKE_FLAGS} -sf -`
 CC=`printf "all:\\n\\t@echo \\\$(CC)\\n" | make ${MAKE_FLAGS} -sf -`
 CFLAGS=`printf "all:\\n\\t@echo \\\$(CFLAGS)\\n" | make ${MAKE_FLAGS} -sf -`
 CFLAGS="${CFLAGS} -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes"
@@ -2434,6 +2435,7 @@ exec > Makefile.configure
 [ -z "${INSTALL_DATA}"    ] && INSTALL_DATA="${INSTALL} -m 0444"
 
 cat << __HEREDOC__
+AR		 = ${AR}
 CC		 = ${CC}
 CFLAGS		 = ${CFLAGS}
 CPPFLAGS	 = ${CPPFLAGS}

--- a/configure.in
+++ b/configure.in
@@ -75,9 +75,10 @@ fi
 
 #----------------------------------------------------------------------
 # Initialize all variables here such that nothing can leak in from the
-# environment except for CC and CFLAGS, which we might have passed in.
+# environment except for AR, CC and CFLAGS, which we might have passed in.
 #----------------------------------------------------------------------
 
+AR=`printf "all:\\n\\t@echo \\\$(AR)\\n" | make ${MAKE_FLAGS} -sf -`
 CC=`printf "all:\\n\\t@echo \\\$(CC)\\n" | make ${MAKE_FLAGS} -sf -`
 CFLAGS=`printf "all:\\n\\t@echo \\\$(CFLAGS)\\n" | make ${MAKE_FLAGS} -sf -`
 CFLAGS="${CFLAGS} -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes"
@@ -1076,6 +1077,7 @@ exec > Makefile.configure
 [ -z "${INSTALL_DATA}"    ] && INSTALL_DATA="${INSTALL} -m 0444"
 
 cat << __HEREDOC__
+AR		 = ${AR}
 CC		 = ${CC}
 CFLAGS		 = ${CFLAGS}
 CPPFLAGS	 = ${CPPFLAGS}


### PR DESCRIPTION
This can be used in order to use llvm-ar, instead of GNU.