### PR TITLE
Define _GNU_SOURCE and _DEFAULT_SOURCE on WASI

### DIFF
--- a/configure
+++ b/configure
@@ -418,7 +418,7 @@ cat << __HEREDOC__
 #if !defined(__GNUC__) || (__GNUC__ < 4)
 # define __attribute__(x)
 #endif
-#if defined(__linux__) || defined(__MINT__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
 # define _GNU_SOURCE /* memmem, memrchr, setresuid... */
 # define _DEFAULT_SOURCE /* le32toh, crypt, ... */
 #endif

--- a/configure.in
+++ b/configure.in
@@ -418,7 +418,7 @@ cat << __HEREDOC__
 #if !defined(__GNUC__) || (__GNUC__ < 4)
 # define __attribute__(x)
 #endif
-#if defined(__linux__) || defined(__MINT__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
 # define _GNU_SOURCE /* memmem, memrchr, setresuid... */
 # define _DEFAULT_SOURCE /* le32toh, crypt, ... */
 #endif

--- a/test-crypt.c
+++ b/test-crypt.c
@@ -1,4 +1,4 @@
-#if defined(__linux__)
+#if defined(__linux__) || defined(__wasi__)
 # define _GNU_SOURCE /* old glibc */
 # define _DEFAULT_SOURCE /* new glibc */
 #endif

--- a/test-endian_h.c
+++ b/test-endian_h.c
@@ -1,4 +1,4 @@
-#ifdef __linux__
+#if defined(__linux__) || defined(__wasi__)
 # define _DEFAULT_SOURCE
 #endif
 #include <endian.h>

--- a/test-memrchr.c
+++ b/test-memrchr.c
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__MINT__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
 #define _GNU_SOURCE	/* See test-*.c what needs this. */
 #endif
 #include <string.h>

--- a/tests.c
+++ b/tests.c
@@ -40,7 +40,7 @@ main(void)
 }
 #endif /* TEST_CAPSICUM */
 #if TEST_CRYPT
-#if defined(__linux__)
+#if defined(__linux__) || defined(__wasi__)
 # define _GNU_SOURCE /* old glibc */
 # define _DEFAULT_SOURCE /* new glibc */
 #endif
@@ -82,7 +82,7 @@ main(void)
 }
 #endif /* TEST_CRYPT_NEWHASH */
 #if TEST_ENDIAN_H
-#ifdef __linux__
+#if defined(__linux__) || defined(__wasi__)
 # define _DEFAULT_SOURCE
 #endif
 #include <endian.h>
@@ -292,7 +292,7 @@ main(void)
 }
 #endif /* TEST_MEMMEM */
 #if TEST_MEMRCHR
-#if defined(__linux__) || defined(__MINT__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
 #define _GNU_SOURCE	/* See test-*.c what needs this. */
 #endif
 #include <string.h>


### PR DESCRIPTION
This probably needs further improvement, as checking for __linux__ as a
proxy for the availability of memmem etc. or _GNU_SOURCE, is not exactly
right. For the time being, just do the minimum required change, and
extend to check also for __wasi__.