### PR TITLE
configure.in: move FTS inside OCONFIGURE_CONFIG_H

### DIFF
--- a/configure
+++ b/configure
@@ -2361,10 +2361,6 @@ name##_RB_MINMAX(struct name *head, int val)				\\
 __HEREDOC__
 fi
 
-cat << __HEREDOC__
-#endif /*!OCONFIGURE_CONFIG_H*/
-__HEREDOC__
-
 if [ ${HAVE_FTS} -eq 0 ]; then
 	cat << __HEREDOC__
 /*
@@ -2448,6 +2444,10 @@ int	 fts_set(FTS *, FTSENT *, int);
 
 __HEREDOC__
 fi
+
+cat << __HEREDOC__
+#endif /*!OCONFIGURE_CONFIG_H*/
+__HEREDOC__
 
 echo "config.h: written" 1>&2
 echo "config.h: written" 1>&3

--- a/configure.in
+++ b/configure.in
@@ -1003,10 +1003,6 @@ if [ ${HAVE_SYS_TREE} -eq 0 ]; then
 __HEREDOC__
 fi
 
-cat << __HEREDOC__
-#endif /*!OCONFIGURE_CONFIG_H*/
-__HEREDOC__
-
 if [ ${HAVE_FTS} -eq 0 ]; then
 	cat << __HEREDOC__
 /*
@@ -1090,6 +1086,10 @@ int	 fts_set(FTS *, FTSENT *, int);
 
 __HEREDOC__
 fi
+
+cat << __HEREDOC__
+#endif /*!OCONFIGURE_CONFIG_H*/
+__HEREDOC__
 
 echo "config.h: written" 1>&2
 echo "config.h: written" 1>&3


### PR DESCRIPTION
The FTS header code was accidentally included outside the OCONFIGURE_CONFIG_H ifndef/endif guard, and thus prone to redefinition if the header was included multiple times. Move it inside the ifndef guard.