### PR TITLE
configure.in: Use portable invocation of mktemp

### DIFF
--- a/configure
+++ b/configure
@@ -98,7 +98,7 @@ done
 # exit.  This simplifies the script from needing to tidy up everything
 # directly.
 
-TMPROOT=$(mktemp -d) || exit 1
+TMPROOT=$(mktemp -d -t tmproot.XXXXXX) || exit 1
 # shellcheck disable=SC2064
 trap "rm -rf \"$TMPROOT\"" EXIT
 

--- a/configure.in
+++ b/configure.in
@@ -98,7 +98,7 @@ done
 # exit.  This simplifies the script from needing to tidy up everything
 # directly.
 
-TMPROOT=$(mktemp -d) || exit 1
+TMPROOT=$(mktemp -d -t tmproot.XXXXXX) || exit 1
 # shellcheck disable=SC2064
 trap "rm -rf \"$TMPROOT\"" EXIT
 


### PR DESCRIPTION
On legacy OSX systems, `mktemp -d` doesn't suffice in order to create a temporary directory, which leads to various issues when building other software utilizing this project (most notably, [`lowdown` on MacPorts, OSX 10.7.5](https://trac.macports.org/ticket/73714)).

A simple solution is to use a more portable invocation to cover a wide range of operating systems, per the examples below (OSX 10.7.5 and macOS 15.6.1, respectively)

```console
lion:lowdown maniac$ mktemp -d -t tmproot.XXXXXX
/var/folders/5r/qh63gph55wx79g9cd7yjwhtc0000gn/T/tmproot.XXXXXX.I6OYR1SQ
```

```console
maniac@sequoia lowdown % mktemp -d -t tmproot.XXXXXX
/var/folders/x1/44rw8ngx2gl8sdy9bfs2_8yc0000gp/T/tmproot.XXXXXX.IacEZctSvb
```

This solution also maintains compatibility with Linux-based distros (e.g, Debian 13.4.0, in this case)

```console
maniac@debian:~/workspace/lowdown $ mktemp -d -t tmproot.XXXXXX
/tmp/tmproot.HJAXSe
```