### PR TITLE
Support GNU Hurd.

### DIFF
--- a/configure
+++ b/configure
@@ -715,7 +715,7 @@ cat << __HEREDOC__
 #if !defined(__GNUC__) || (__GNUC__ < 4)
 # define __attribute__(x)
 #endif
-#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__) || defined(__GNU__)
 # define _GNU_SOURCE /* memmem, memrchr, setresuid... */
 # define _DEFAULT_SOURCE /* le32toh, crypt, ... */
 #endif

--- a/configure.in
+++ b/configure.in
@@ -715,7 +715,7 @@ cat << __HEREDOC__
 #if !defined(__GNUC__) || (__GNUC__ < 4)
 # define __attribute__(x)
 #endif
-#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__) || defined(__GNU__)
 # define _GNU_SOURCE /* memmem, memrchr, setresuid... */
 # define _DEFAULT_SOURCE /* le32toh, crypt, ... */
 #endif

--- a/test-crypt.c
+++ b/test-crypt.c
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__wasi__)
+#if defined(__linux__) || defined(__wasi__) || defined(__GNU__)
 # define _DEFAULT_SOURCE /* new glibc */
 # define _XOPEN_SOURCE /* old glibc */
 #endif

--- a/test-endian_h.c
+++ b/test-endian_h.c
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__wasi__)
+#if defined(__linux__) || defined(__wasi__) || defined(__GNU__)
 # define _DEFAULT_SOURCE
 #endif
 #include <endian.h>

--- a/test-memrchr.c
+++ b/test-memrchr.c
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__) || defined(__GNU__)
 #define _GNU_SOURCE	/* See test-*.c what needs this. */
 #endif
 #include <string.h>

--- a/tests.c
+++ b/tests.c
@@ -85,7 +85,7 @@ main(void)
 }
 #endif /* TEST_CAPSICUM */
 #if TEST_CRYPT
-#if defined(__linux__) || defined(__wasi__)
+#if defined(__linux__) || defined(__wasi__) || defined(__GNU__)
 # define _DEFAULT_SOURCE /* new glibc */
 # define _XOPEN_SOURCE /* old glibc */
 #endif
@@ -126,7 +126,7 @@ main(void)
 }
 #endif /* TEST_CRYPT_NEWHASH */
 #if TEST_ENDIAN_H
-#if defined(__linux__) || defined(__wasi__)
+#if defined(__linux__) || defined(__wasi__) || defined(__GNU__)
 # define _DEFAULT_SOURCE
 #endif
 #include <endian.h>
@@ -336,7 +336,7 @@ main(void)
 }
 #endif /* TEST_MEMMEM */
 #if TEST_MEMRCHR
-#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__) || defined(__GNU__)
 #define _GNU_SOURCE	/* See test-*.c what needs this. */
 #endif
 #include <string.h>


### PR DESCRIPTION
Extend the existing `#ifdef` for Linux / MINT / WASI to check `__GNU__`, which sets the `_GNU_SOURCE` define needed to build on Hurd.

Regenerate `configure` after that change.

re kristapsdz/openrsync#36